### PR TITLE
Modification of the root link (tree -> resolve) in odinw download code.

### DIFF
--- a/odinw/download.py
+++ b/odinw/download.py
@@ -6,7 +6,7 @@ argparser.add_argument("--dataset_names", default="all", type=str) # "all" or na
 argparser.add_argument("--dataset_path", default="DATASET/odinw", type=str)
 args = argparser.parse_args()
 
-root = "https://huggingface.co/GLIPModel/GLIP/tree/main/odinw_35"
+root = "https://huggingface.co/GLIPModel/GLIP/resolve/main/odinw_35"
 
 all_datasets = ["AerialMaritimeDrone", "AmericanSignLanguageLetters", "Aquarium", "BCCD", "ChessPieces", "CottontailRabbits", "DroneControl", "EgoHands", "HardHatWorkers", "MaskWearing", "MountainDewCommercial", "NorthAmericaMushrooms", "OxfordPets", "PKLot", "Packages", "PascalVOC", "Raccoon", "ShellfishOpenImages", "ThermalCheetah", "UnoCards", "VehiclesOpenImages", "WildfireSmoke", "boggleBoards", "brackishUnderwater", "dice", "openPoetryVision", "pistols", "plantdoc", "pothole", "selfdrivingCar", "thermalDogsAndPeople", "vector", "websiteScreenshots"]
 


### PR DESCRIPTION
Originally, the root str was "https://huggingface.co/GLIPModel/GLIP/tree/main/odinw_35".
This didn't work since this page doesn't contain the data. Just UI.
I corrected this error by replacing "tree" with "revolve",